### PR TITLE
Refatorar GUI para chamar conversão internamente

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ pyinstaller opus_folder_to_matrix.py
 # O binário resultante ficará em dist/opus_folder_to_matrix/
 ```
 
+Para empacotar a interface gráfica basta apontar o PyInstaller para o módulo
+da GUI:
+
+```bash
+pyinstaller --onefile opus_folder_to_matrix_gui.py
+```
+
+Como ``opus_folder_to_matrix_gui.py`` importa diretamente o módulo de
+conversão, não é necessário utilizar opções extras como ``--add-data`` para que
+o script principal seja incluído no executável.
+
 # Licença
 
 Este projeto não possui uma licença explícita. Entre em contato com os


### PR DESCRIPTION
## Summary
- adicionar o helper programático `run()` em `opus_folder_to_matrix.py` para reaproveitar a lógica de conversão sem recorrer ao `sys.executable`
- atualizar a interface Tkinter para usar a nova função, capturando o log e exibindo os caminhos gerados em vez de abrir um novo processo
- documentar no README que o PyInstaller coleta o módulo principal automaticamente ao empacotar a GUI

## Testing
- python -m compileall .
- python - <<'PY' … (execução com leitor falso para validar `run()` e geração dos CSVs)
- pyinstaller --onefile opus_folder_to_matrix_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68c99dc3b2788331ab79267e7bb6b08d