### PR TITLE
Normalize numeric OPUS extensions during scan

### DIFF
--- a/opus_folder_to_matrix.py
+++ b/opus_folder_to_matrix.py
@@ -209,11 +209,12 @@ def scan_opus_files(folder: Path) -> List[Path]:
     if not folder.is_dir():
         raise NotADirectoryError(folder)
 
-    exts: Set[str] = {".0", ".OPUS", ".opus", ".spc", ".sp"}
+    exts: Set[str] = {".0", ".opus", ".spc", ".sp"}
     files: List[Path] = []
     for p in folder.rglob("*"):
         if p.is_file():
-            if p.suffix in exts or p.suffix == "":
+            suffix = p.suffix.lower()
+            if suffix in exts or (suffix.startswith(".") and suffix[1:].isdigit()) or suffix == "":
                 files.append(p)
     # Ordem estável por nome
     files.sort()


### PR DESCRIPTION
## Summary
- normalize scanned file suffixes to lowercase before matching with the allowed OPUS extensions
- accept purely numeric suffixes (e.g., .01, .10) in addition to the traditional OPUS file extensions

## Testing
- python - <<'PY' ... (manual snippet to ensure scan_opus_files collects .01/.02 files)
- python opus_folder_to_matrix.py "$tmpdir" 2>&1 | head


------
https://chatgpt.com/codex/tasks/task_e_68c9a93e93ac8331b96972298f3ee24f